### PR TITLE
Fix missing "type": "http" in README config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Model Context Protocol (MCP) server implementation that integrates with [SerpA
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Install in VS Code](https://img.shields.io/badge/Install%20in-VS%20Code-blue?logo=visualstudiocode)](https://insiders.vscode.dev/redirect/mcp/install?name=serpapi-mcp&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.serpapi.com%2FYOUR_SERPAPI_API_KEY%2Fmcp%22%7D)
+[![Install in Cursor](https://img.shields.io/badge/Install%20in-Cursor-blue?logo=cursor)](cursor://anysphere.cursor-deeplink/mcp/install?name=serpapi-mcp&config=eyJ0eXBlIjoiaHR0cCIsInVybCI6Imh0dHBzOi8vbWNwLnNlcnBhcGkuY29tL1lPVVJfU0VSUEFQSV9BUElfS0VZL21jcCJ9)
 
 ## Features
 
@@ -26,6 +27,7 @@ You can configure Claude Desktop to use the hosted server:
 {
   "mcpServers": {
     "serpapi": {
+      "type": "http",
       "url": "https://mcp.serpapi.com/YOUR_SERPAPI_API_KEY/mcp"
     }
   }
@@ -44,6 +46,7 @@ Configure Claude Desktop:
 {
   "mcpServers": {
     "serpapi": {
+      "type": "http",
       "url": "http://localhost:8000/YOUR_SERPAPI_API_KEY/mcp"
     }
   }

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
   },
   "remotes": [
     {
-      "type": "sse",
+      "type": "http",
       "url": "https://mcp.serpapi.com/mcp"
     }
   ]


### PR DESCRIPTION
Fixes https://github.com/serpapi/public-roadmap/issues/3740

## Changelog

MCP clients like Claude Code require explicit `"type": "http"` in the JSON config to identify the transport. Also updates server.json from deprecated "sse" to "http" and adds a Cursor one-click install badge.
