### PR TITLE
[MCP] Add offline pytest suite + tests CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          # Pin uv and Python for reproducible, deterministic runs.
+          version: "0.11.8"
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Run tests
+        run: uv run pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21.0",
+    "requests>=2",
     "black>=23.0",
     "isort>=5.12.0",
     "flake8>=6.0.0",
@@ -68,3 +69,7 @@ python_version = "3.13"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/src/server.py
+++ b/src/server.py
@@ -294,9 +294,8 @@ async def search(params: dict[str, Any] = None, mode: str = "complete") -> str:
         params = {}
 
     request = get_http_request()
-    if hasattr(request, "state") and request.state.api_key:
-        api_key = request.state.api_key
-    else:
+    api_key = getattr(getattr(request, "state", None), "api_key", None)
+    if not api_key:
         return "Error: Unable to access API key from request context"
 
     search_params = {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,20 @@
+"""Live contract test. Skipped unless SERPAPI_KEY is set, so CI stays green
+without a key. It validates the one boundary the unit tests mock: that
+serpapi.search returns a SerpResults whose as_dict carries organic_results.
+"""
+
+import os
+
+import pytest
+import serpapi
+
+KEY = os.getenv("SERPAPI_KEY")
+
+
+@pytest.mark.skipif(
+    not KEY, reason="set SERPAPI_KEY to run the live SerpApi contract test"
+)
+def test_live_search_returns_organic_results():
+    results = serpapi.search({"engine": "google_light", "q": "coffee", "api_key": KEY})
+    data = results.as_dict()
+    assert "organic_results" in data

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,304 @@
+"""Offline unit tests for src/server.py.
+
+The SerpApi client and the HTTP request are built from the real library types
+(serpapi.SerpResults, a real requests/serpapi HTTPError, a real starlette
+Request), so the suite pins the actual library contract without a network call
+or an API key.
+"""
+
+import json
+
+import pytest
+import requests
+import serpapi
+from serpapi.models import SerpResults
+from starlette.requests import Request
+
+import src.server as server
+
+
+def make_serpapi_http_error(
+    status, body, reason="Error", url="https://serpapi.com/search?q=x"
+):
+    """Build the exception the way the serpapi client does: a requests HTTPError
+    from raise_for_status(), wrapped in serpapi's HTTPError. The wrapper's own
+    .response is None; the body lives on args[0].response."""
+    resp = requests.Response()
+    resp.status_code = status
+    resp.reason = reason
+    resp.url = url
+    resp._content = json.dumps(body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    try:
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as exc:
+        return serpapi.exceptions.HTTPError(exc)
+    raise AssertionError("raise_for_status did not raise")
+
+
+def real_request(path="/mcp", headers=None, state=None):
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "raw_path": path.encode(),
+        "headers": raw,
+        "query_string": b"",
+        "scheme": "http",
+        "server": ("testserver", 80),
+    }
+    if state is not None:
+        scope["state"] = dict(state)
+    return Request(scope)
+
+
+def serp_results(payload):
+    return SerpResults(payload, client=None)
+
+
+def use_request(monkeypatch, request):
+    monkeypatch.setattr(server, "get_http_request", lambda: request)
+
+
+def use_search(monkeypatch, fn):
+    monkeypatch.setattr(server.serpapi, "search", fn)
+
+
+def raiser(exc):
+    def _search(params):
+        raise exc
+
+    return _search
+
+
+class _Wrap(Exception):
+    """An exception whose single arg is its inner cause — mirrors how serpapi
+    wraps a requests error in args[0]. extract_error_response walks this chain."""
+
+
+class _Resp:
+    """Minimal stand-in for a requests.Response: only .json() is exercised."""
+
+    def __init__(self, body):
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+class _WithResponse(Exception):
+    def __init__(self, response):
+        super().__init__("boom")
+        self.response = response
+
+
+def nest(depth, leaf):
+    """Wrap `leaf` `depth` times so it sits at args[0]-chain index `depth`."""
+    cur = leaf
+    for _ in range(depth):
+        cur = _Wrap(cur)
+    return cur
+
+
+def test_extract_error_response_reads_json_body_from_wrapped_request_error():
+    err = make_serpapi_http_error(400, {"error": "Invalid API key."})
+    assert (
+        err.response is None
+    )  # the wrapper has no response; the body is one level down
+    assert json.loads(server.extract_error_response(err)) == {
+        "error": "Invalid API key."
+    }
+
+
+def test_extract_error_response_falls_back_to_response_text_when_not_json():
+    resp = requests.Response()
+    resp.status_code = 502
+    resp.url = "https://serpapi.com/search"
+    resp._content = b"upstream boom"
+    try:
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as exc:
+        err = serpapi.exceptions.HTTPError(exc)
+    assert server.extract_error_response(err) == "upstream boom"
+
+
+def test_extract_error_response_falls_back_to_str():
+    assert server.extract_error_response(ValueError("plain message")) == "plain message"
+
+
+def test_extract_error_response_terminates_and_returns_innermost_message():
+    err = ValueError("deepest")
+    for _ in range(20):
+        err = ValueError(err)
+    # 20 levels deep with no .response anywhere: the walk must terminate (not
+    # hang) and fall back to the chain's message string.
+    assert server.extract_error_response(err) == "deepest"
+
+
+def test_extract_error_response_finds_response_at_depth_cap_boundary():
+    leaf = _WithResponse(_Resp({"error": "deep"}))
+    # index 9 is the last position the depth cap (10) still inspects.
+    err = nest(9, leaf)
+    assert json.loads(server.extract_error_response(err)) == {"error": "deep"}
+
+
+def test_extract_error_response_stops_one_past_the_depth_cap():
+    leaf = _WithResponse(_Resp({"error": "too deep"}))
+    # index 10 is one past the cap: the body must never be reached.
+    err = nest(10, leaf)
+    out = server.extract_error_response(err)
+    assert "too deep" not in out  # cap enforced, not just "returns a string"
+    assert out == "boom"  # falls back to str() of the chain
+
+
+async def test_search_rejects_invalid_mode():
+    out = await server.search(params={"q": "x"}, mode="bogus")
+    assert out == "Error: Invalid mode. Must be 'complete' or 'compact'"
+
+
+async def test_search_without_api_key_returns_graceful_error(monkeypatch):
+    # A real starlette Request with empty state: request.state.api_key would raise
+    # AttributeError, so the guard must use getattr, not attribute access.
+    use_request(monkeypatch, real_request(state={}))
+    out = await server.search(params={"q": "x"})
+    assert out == "Error: Unable to access API key from request context"
+
+
+async def test_search_complete_returns_full_payload(monkeypatch):
+    payload = {"search_metadata": {"id": "1"}, "organic_results": [{"title": "hit"}]}
+    use_request(monkeypatch, real_request(state={"api_key": "KEY"}))
+    use_search(monkeypatch, lambda params: serp_results(payload))
+    assert json.loads(await server.search(params={"q": "x"})) == payload
+
+
+async def test_search_compact_strips_serpapi_metadata(monkeypatch):
+    payload = {
+        "search_metadata": {},
+        "search_parameters": {},
+        "search_information": {},
+        "pagination": {},
+        "serpapi_pagination": {},
+        "organic_results": [{"title": "hit"}],
+    }
+    use_request(monkeypatch, real_request(state={"api_key": "KEY"}))
+    use_search(monkeypatch, lambda params: serp_results(payload))
+    out = json.loads(await server.search(params={"q": "x"}, mode="compact"))
+    assert out == {"organic_results": [{"title": "hit"}]}
+
+
+async def test_search_compact_does_not_mutate_the_live_result(monkeypatch):
+    payload = {"search_metadata": {"id": "1"}, "organic_results": [{"title": "hit"}]}
+    results = serp_results(payload)
+    use_request(monkeypatch, real_request(state={"api_key": "KEY"}))
+    use_search(monkeypatch, lambda params: results)
+    await server.search(params={"q": "x"}, mode="compact")
+    assert "search_metadata" in results.as_dict()
+
+
+async def test_search_forwards_api_key_and_default_engine(monkeypatch):
+    captured = {}
+
+    def capture(params):
+        captured.update(params)
+        return serp_results({"ok": True})
+
+    use_request(monkeypatch, real_request(state={"api_key": "KEY"}))
+    use_search(monkeypatch, capture)
+    await server.search(params={"q": "x"})
+    assert captured["api_key"] == "KEY"
+    assert captured["engine"] == "google_light"
+    assert captured["q"] == "x"
+
+
+async def test_search_caller_overrides_default_engine(monkeypatch):
+    captured = {}
+
+    def capture(params):
+        captured.update(params)
+        return serp_results({})
+
+    use_request(monkeypatch, real_request(state={"api_key": "KEY"}))
+    use_search(monkeypatch, capture)
+    await server.search(params={"q": "x", "engine": "google_news"})
+    assert captured["engine"] == "google_news"
+
+
+@pytest.mark.parametrize(
+    "status, fragment",
+    [
+        (429, "Rate limit exceeded"),
+        (401, "Invalid SerpApi API key"),
+        (403, "forbidden"),
+    ],
+)
+async def test_search_maps_real_http_errors(monkeypatch, status, fragment):
+    use_request(monkeypatch, real_request(state={"api_key": "KEY"}))
+    use_search(monkeypatch, raiser(make_serpapi_http_error(status, {"error": "x"})))
+    out = await server.search(params={"q": "x"})
+    assert out.startswith("Error:")
+    assert fragment in out
+
+
+async def test_search_unmapped_http_error_returns_json_body(monkeypatch):
+    use_request(monkeypatch, real_request(state={"api_key": "KEY"}))
+    use_search(
+        monkeypatch, raiser(make_serpapi_http_error(500, {"error": "server boom"}))
+    )
+    out = await server.search(params={"q": "x"})
+    assert out.startswith("Error:")
+    assert "server boom" in out
+
+
+async def test_search_generic_exception_uses_extractor(monkeypatch):
+    use_request(monkeypatch, real_request(state={"api_key": "KEY"}))
+    use_search(monkeypatch, raiser(ValueError("weird failure")))
+    assert await server.search(params={"q": "x"}) == "Error: weird failure"
+
+
+async def passthrough(request):
+    return "OK"
+
+
+async def test_middleware_skips_healthcheck():
+    mw = server.ApiKeyMiddleware(app=lambda *a, **k: None)
+    assert await mw.dispatch(real_request(path="/healthcheck"), passthrough) == "OK"
+
+
+async def test_middleware_extracts_bearer_token():
+    mw = server.ApiKeyMiddleware(app=lambda *a, **k: None)
+    request = real_request(path="/mcp", headers={"Authorization": "Bearer ABC123"})
+    assert await mw.dispatch(request, passthrough) == "OK"
+    assert request.state.api_key == "ABC123"
+
+
+async def test_middleware_extracts_path_key_and_rewrites_path():
+    mw = server.ApiKeyMiddleware(app=lambda *a, **k: None)
+    request = real_request(path="/MYKEY/mcp")
+    assert await mw.dispatch(request, passthrough) == "OK"
+    assert request.state.api_key == "MYKEY"
+    assert request.scope["path"] == "/mcp"
+
+
+async def test_middleware_returns_401_without_key():
+    mw = server.ApiKeyMiddleware(app=lambda *a, **k: None)
+    response = await mw.dispatch(real_request(path="/mcp"), passthrough)
+    assert response.status_code == 401
+
+
+async def test_middleware_ignores_non_mcp_two_segment_path():
+    # /foo/bar has two segments but the second isn't "mcp", so the first segment
+    # must NOT be treated as an API key — the guard requires path_parts[1] == "mcp".
+    mw = server.ApiKeyMiddleware(app=lambda *a, **k: None)
+    response = await mw.dispatch(real_request(path="/foo/bar"), passthrough)
+    assert response.status_code == 401
+
+
+async def test_healthcheck_returns_healthy_with_utc_timestamp():
+    resp = await server.healthcheck_handler(real_request(path="/healthcheck"))
+    assert resp.status_code == 200
+    body = json.loads(resp.body)
+    assert body["status"] == "healthy"
+    assert body["service"] == "SerpApi MCP Server"
+    # timezone-aware UTC, Z-suffixed (utcnow() was deprecated on 3.12+).
+    assert body["timestamp"].endswith("Z")

--- a/uv.lock
+++ b/uv.lock
@@ -1345,6 +1345,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "requests" },
 ]
 
 [package.metadata]
@@ -1360,6 +1361,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "requests", marker = "extra == 'dev'", specifier = ">=2" },
     { name = "serpapi", specifier = ">=0.1.5" },
     { name = "starlette", specifier = ">=0.50.0" },
     { name = "uvicorn", specifier = ">=0.38.0" },


### PR DESCRIPTION
Opened this as a follow-up to #35. It's small and self-contained (an offline test suite, a CI workflow, and a one-line fix), so a PR felt easier to look at than a long description. If splitting it up or trimming the scope makes it easier to review, just say so and I'll redo it.

## What
Adds an offline unit-test suite for `src/server.py`, a tests CI workflow, and a one-line fix for a crash the tests surfaced.

## The bug
`search` reads `request.state.api_key` directly. On a real starlette Request whose State has no `api_key`, that throws an uncaught `AttributeError` (the read sits outside the try/except), so the no-key path returns a 500 instead of the intended "Unable to access API key from request context" string. Fixed with `getattr(getattr(request, "state", None), "api_key", None)`.

## Tests (24 passed, 1 skipped locally)
Built from the real library types so they pin the actual contract with no network and no API key:
- `extract_error_response`: JSON body read off `args[0].response` (the serpapi wrapper's own `.response` is None), text fallback, str fallback, and the depth-cap boundary (finds a response at the limit, stops one past it).
- `search`: mode validation, compact strip on a copy (no mutation of the live result), api_key forwarding + engine default/override, real 429/401/403 mapping + JSON-body extraction on unmapped errors, the no-key path.
- `ApiKeyMiddleware`: Bearer vs path `/{KEY}/mcp` extraction + path rewrite, `/healthcheck` bypass, 401 with no key, two-segment non-mcp path.
- `healthcheck_handler`: healthy payload shape.
- One key-gated (`skipif SERPAPI_KEY`) live contract test, skipped in CI.

## CI
New `tests.yml` runs `uv run pytest` on PRs and pushes (pinned uv and Python, cached, `uv sync --frozen`, concurrency-cancel). Additive, `format_check.yml` is untouched. Also declares `requests` as a direct dev dependency, since the tests build a real `requests.Response` and it was previously only pulled in transitively through `serpapi`.

`uv format --check` passes.
